### PR TITLE
Declare dependencies in pyproject.toml

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -9,9 +9,6 @@ You can install qpageview without downloading it first via ``pip``::
 
     pip install qpageview
 
-
-You can also install from the source directory::
-
-    python3 setup.py install
-
-
+Use ``pip install qpageview[pdf]`` to ensure qpageview has PDF support,
+and ``pip qpageview[cups]`` for CUPS printing support (can be combined
+as ``pip install qpageview[pdf,cups]``).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qpageview"
 dynamic = ["version"]
+dependencies = ["PyQt5"]
+optional-dependencies = {pdf = ["python-poppler-qt5"], cups = ["pycups"]}
+requires-python = ">= 3.6"
 description = "Widget to display page-based documents for Qt5/PyQt5"
 readme = "README.rst"
 maintainers = [{name = "Wilbert Berendsen", email = "info@frescobaldi.org"}]


### PR DESCRIPTION
With this change

$ pip install qpageview

will automatically install PyQt5.

$ pip install qpageview[pdf]

also installs python-poppler-qt5, and

$ pip install qpageview[cups]

also installs pycups.

Also use requires-python to enforce the documented requirement from README.rst.

Fixes #16