### PR TITLE
Use hatchling as build backend

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include README.rst INSTALL.rst ChangeLog LICENSE
-graft docs
-prune docs/build
-prune docs/web/build
-recursive-include tests *.py
-global-exclude *~ *.py[cod] __pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools >= 64"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "qpageview"
@@ -28,5 +28,6 @@ Homepage = "https://github.com/frescobaldi/qpageview"
 Documentation = "https://qpageview.org"
 "Issue tracker" = "https://github.com/frescobaldi/qpageview/issues"
 
-[tool.setuptools.dynamic]
-version.attr = "qpageview.pkginfo.version_string"
+[tool.hatch.version]
+path = "qpageview/pkginfo.py"
+pattern = "version_string = \"(?P<version>.*)\""


### PR DESCRIPTION
It's a lot less verbose than setuptools, doesn't leave .egg-info directories around, and has simpler file selection configuration.