### PR TITLE
Docs 1.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,3 +1,3 @@
 :orphan:
 
-.. include:: ../../ChangeLog
+.. mdinclude:: ../../CHANGELOG.md

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,7 @@ extensions = [
 #    'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
+    'sphinx_mdinclude',
 ]
 
 # autodoc
@@ -74,8 +75,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = "python-ly"
-copyright = "2020-2022, Wilbert Berendsen"
+project = "qpageview"
+copyright = "2020-2025, Wilbert Berendsen"
 author = "Wilbert Berendsen"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -93,7 +94,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/rendering.rst
+++ b/docs/source/rendering.rst
@@ -55,6 +55,11 @@ types:
      - :class:`~svg.SvgDocument`
      - SVG images, one file per page
 
+   * - :mod:`~qpageview.pdf`
+     - :class:`~pdf.PdfPage`
+     - :class:`~pdf.PdfDocument`
+     - PDF documents, multiple pages per file
+
    * - :mod:`~qpageview.poppler`
      - :class:`~poppler.PopplerPage`
      - :class:`~poppler.PopplerDocument`

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -11,7 +11,7 @@ Just import :mod:`qpageview` and create a View. As the :class:`~view.View` is a
 QWidget, you need to create a QApplication object, just as for all Qt-based
 applications::
 
-    from PyQt5.QtWidgets import QApplication
+    from PyQt6.QtWidgets import QApplication
     import qpageview
 
     app = QApplication([])


### PR DESCRIPTION
I've started updating the docs for the next release. I created this branch from v1.0 branch,  so this PR would depend on #32 

@bmjcode I would need your help to review the parts of the docs that are not autogenerated from the source files.
If you don't want to bother with Sphinx building, I may add already a GitHub action to build the html files and push them to gh-pages branch.

I'm still getting these warnings when I run sphinx-build:

```
reading sources... [100%] widgetoverlay
docstring of qpageview.printing.PrintJob.progress:1: WARNING: Inline emphasis start-string without end-string. [docutils]
docstring of qpageview.rubberband.Rubberband.selectionChanged:1: WARNING: Inline emphasis start-string without end-string. [docutils]
docstring of qpageview.selector.SelectorViewMixin.selectionChanged:1: WARNING: Inline emphasis start-string without end-string. [docutils]
docstring of qpageview.selector.SelectorViewMixin.selectionModeChanged:1: WARNING: Inline emphasis start-string without end-string. [docutils]
docstring of qpageview.viewactions.ViewActions.viewRequested:1: WARNING: Inline emphasis start-string without end-string. [docutils]
docstring of qpageview.viewactions.PagerAction.currentPageNumberChanged:1: WARNING: Inline emphasis start-string without end-string. [docutils]
docstring of qpageview.viewactions.ZoomerAction.zoomFactorChanged:1: WARNING: Inline emphasis start-string without end-string. [docutils]
docstring of qpageview.viewactions.ZoomerAction.viewModeChanged:1: WARNING: Inline emphasis start-string without end-string. [docutils]
```
