### PR TITLE
1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ defined at the bottom of this file.
 
 All notable changes to the qpageview project are documented in this file.
 
+## [1.0.1] - 2025-07-04
+
+### Changed
+
+* Remove remaining pieces that depend on Poppler (#35)
+* Raster page layout renamed to Grid Layout (#40)
+
+
 ## [1.0.0] - 2025-01-06
 
 ### Added
@@ -80,3 +88,4 @@ its own project, to make it easier to use this package in other applications.
 [0.6.1]: https://github.com/frescobaldi/qpageview/compare/v0.6.0...v0.6.1
 [0.6.2]: https://github.com/frescobaldi/qpageview/compare/v0.6.1...v0.6.2
 [1.0.0]: https://github.com/frescobaldi/qpageview/compare/v0.6.2...v1.0.0
+[1.0.1]: https://github.com/frescobaldi/qpageview/compare/v1.0.0...v1.0.1

--- a/qpageview/pkginfo.py
+++ b/qpageview/pkginfo.py
@@ -21,4 +21,4 @@
 
 """Version information on the qpageview package."""
 
-version_string = "1.0.0"
+version_string = "1.0.1"


### PR DESCRIPTION
This release is needed for the next release (4.0.4) of Frescobaldi, as a new option name in Frescobaldi preference must match the menu name provided by qpageview module. See https://github.com/frescobaldi/frescobaldi/pull/2027
