### PR TITLE
Fix a couple of instances of missing imports

### DIFF
--- a/qpageview/pdf.py
+++ b/qpageview/pdf.py
@@ -25,11 +25,10 @@ PDF rendering backend using QtPdf.
 
 """
 
-import contextlib
 import weakref
 import platform
 
-from PyQt6.QtCore import Qt, QCoreApplication, QModelIndex, QRect, QRectF, QSize
+from PyQt6.QtCore import Qt, QByteArray, QCoreApplication, QModelIndex, QRect, QRectF, QSize, QUrl
 from PyQt6.QtGui import QPainter
 from PyQt6.QtPdf import QPdfDocument, QPdfDocumentRenderOptions, QPdfLinkModel
 

--- a/qpageview/widgetoverlay.py
+++ b/qpageview/widgetoverlay.py
@@ -25,9 +25,10 @@ View mixin class to display QWidgets on top of a Page.
 
 import collections
 
-from PyQt6.QtCore import QPoint, QRect, Qt
+from PyQt6.QtCore import QPoint, Qt
 
 from . import constants
+from . import util
 
 
 OverlayData = collections.namedtuple("OverlayData", "page point rect alignment")


### PR DESCRIPTION
First one identified by hand when trying to `loadPdf` a `pathlib.Path` (not currently supported), then expanded my search by leveraging ruff:
    `ruff check --select F821 qpageview/`

While at it, remove a couple of unused imports in the files we're touching. A more comprehensive fix can be applied with:
    `ruff check --select F401 --fix qpageview/`