### PR TITLE
Fix a memory leak caused by uncollected QPdfDocument garbage

### DIFF
--- a/qpageview/pdf.py
+++ b/qpageview/pdf.py
@@ -27,7 +27,7 @@ PDF rendering backend using QtPdf.
 
 import platform
 
-from PyQt6.QtCore import Qt, QByteArray, QCoreApplication, QModelIndex, QRect, QRectF, QSize, QUrl
+from PyQt6.QtCore import Qt, QByteArray, QModelIndex, QRect, QRectF, QSize, QUrl
 from PyQt6.QtGui import QPainter
 from PyQt6.QtPdf import QPdfDocument, QPdfDocumentRenderOptions
 
@@ -324,7 +324,9 @@ def load(source):
     if isinstance(source, QPdfDocument):
         return source
     elif isinstance(source, str) or isinstance(source, QByteArray):
-        document = QPdfDocument(QCoreApplication.instance())
+        # We need to create the QPdfDocument without a parent QObject so
+        # Python can garbage-collect it properly when it goes out of scope
+        document = QPdfDocument(None)   # parent has no default value
         document.load(source)
         return document
 


### PR DESCRIPTION
When I wrote this code, I incorrectly assumed that QPdfDocument needed a parent QObject because it did not default to `parent=None`. For lack of a more convenient alternative, I used the application instance as the parent, which had the unfortunate effect of causing QPdfDocument objects to never go out of scope or be garbage-collected when no longer needed.

It turns out creating a QPdfDocument without a parent is apparently fine, and Qt's PDF API is just quirky and poorly documented.

This likely fixes frescobaldi/frescobaldi#2159.