### PR TITLE
Fix several bugs in the background-painting logic

### DIFF
--- a/qpageview/export.py
+++ b/qpageview/export.py
@@ -257,9 +257,10 @@ class ImageExporter(AbstractExporter):
             i = i.convertToFormat(QImage.Format.Format_Grayscale8)
             if self.paperColor is None:
                 # restore the original transparent background
-                mask = i.copy()
-                mask.invertPixels(QImage.InvertMode.InvertRgb)
-                i.setAlphaChannel(mask)
+                i.setAlphaChannel(i)
+                # invert the alpha values so white, not black, is transparent
+                i.invertPixels(QImage.InvertMode.InvertRgba)
+                i.invertPixels(QImage.InvertMode.InvertRgb)
         if self.autocrop:
             i = i.copy(util.autoCropRect(i))
         # needed for correct resolution metadata; see issue #44

--- a/qpageview/export.py
+++ b/qpageview/export.py
@@ -243,11 +243,23 @@ class ImageExporter(AbstractExporter):
         res = self.resolution
         if self.oversample != 1:
             res *= self.oversample
-        i = self.page().image(self._rect, res, res, self.paperColor)
+        if self.grayscale:
+            # convertToFormat() does weird things with the alpha channel,
+            # so we always render grayscale images with a solid background
+            # and handle transparent areas manually if needed
+            paperColor = self.paperColor or Qt.GlobalColor.white
+        else:
+            paperColor = self.paperColor
+        i = self.page().image(self._rect, res, res, paperColor)
         if self.oversample != 1:
             i = i.scaled(i.size() / self.oversample, transformMode=Qt.TransformationMode.SmoothTransformation)
         if self.grayscale:
             i = i.convertToFormat(QImage.Format.Format_Grayscale8)
+            if self.paperColor is None:
+                # restore the original transparent background
+                mask = i.copy()
+                mask.invertPixels(QImage.InvertMode.InvertRgb)
+                i.setAlphaChannel(mask)
         if self.autocrop:
             i = i.copy(util.autoCropRect(i))
         # needed for correct resolution metadata; see issue #44

--- a/qpageview/export.py
+++ b/qpageview/export.py
@@ -257,9 +257,10 @@ class ImageExporter(AbstractExporter):
             i = i.convertToFormat(QImage.Format.Format_Grayscale8)
             if self.paperColor is None:
                 # restore the original transparent background
+                # since our alpha map here is just this image's negative,
+                # we save memory by doing this instead of making a copy()
+                i.invertPixels(QImage.InvertMode.InvertRgb)
                 i.setAlphaChannel(i)
-                # invert the alpha values so white, not black, is transparent
-                i.invertPixels(QImage.InvertMode.InvertRgba)
                 i.invertPixels(QImage.InvertMode.InvertRgb)
         if self.autocrop:
             i = i.copy(util.autoCropRect(i))

--- a/qpageview/pdf.py
+++ b/qpageview/pdf.py
@@ -303,10 +303,6 @@ class PdfRenderer(render.AbstractRenderer):
                 Qt.AspectRatioMode.IgnoreAspectRatio,
                 Qt.TransformationMode.SmoothTransformation)
 
-        # Erase the target area and draw the image
-        painter.eraseRect(target)
-        if paperColor:
-            painter.fillRect(target, paperColor)
         painter.drawImage(target, image, QRectF(image.rect()))
 
 

--- a/qpageview/render.py
+++ b/qpageview/render.py
@@ -219,17 +219,15 @@ class AbstractRenderer:
         The default implementation prepares the image, a painter and then
         calls draw() to actually draw the contents.
 
-        If the paperColor is not specified, it will be read from the Page's
-        paperColor attribute (if not None) or else from the renderer's
-        paperColor attribute.
+        If the paperColor is not specified, the returned image will have a
+        transparent background, and the caller is responsible to paint or
+        erase the background as needed before calling this method.
 
         """
-        if paperColor is None:
-            paperColor = page.paperColor or self.paperColor
-
         i = QImage(tile.w, tile.h, self.imageFormat)
-        if paperColor:
-            i.fill(paperColor)
+        # leave the background transparent if no paperColor is specified,
+        # since we don't necessarily want to fill it e.g. when printing
+        i.fill(paperColor or Qt.GlobalColor.transparent)
         painter = QPainter(i)
 
         # rotate the painter accordingly
@@ -333,6 +331,7 @@ class AbstractRenderer:
         region = QRegion() # painted region in tile coordinates
 
         info = self.info(page, painter.device(), rect)
+        paperColor = page.paperColor or self.paperColor
 
         for t, image in info.images:
             r = QRect(*t) & info.target # part of the tile that needs to be drawn
@@ -365,12 +364,14 @@ class AbstractRenderer:
             else:
                 if QRegion(info.target).subtracted(region):
                     # paint background, still partly uncovered
-                    painter.fillRect(rect, page.paperColor or self.paperColor)
+                    painter.fillRect(rect, paperColor)
 
         # draw lowest quality images first
         for (r, image, source) in reversed(images):
             # scale the target rect back to the paint device
             target = QRectF(r.x() / info.ratio, r.y() / info.ratio, r.width() / info.ratio, r.height() / info.ratio)
+            # remember render() does not fill the background unless requested
+            painter.fillRect(target, paperColor)
             painter.drawImage(target, image, source)
 
     def schedule(self, page, key, tiles, callback):

--- a/qpageview/render.py
+++ b/qpageview/render.py
@@ -331,7 +331,6 @@ class AbstractRenderer:
         region = QRegion() # painted region in tile coordinates
 
         info = self.info(page, painter.device(), rect)
-        paperColor = page.paperColor or self.paperColor
 
         for t, image in info.images:
             r = QRect(*t) & info.target # part of the tile that needs to be drawn
@@ -364,14 +363,14 @@ class AbstractRenderer:
             else:
                 if QRegion(info.target).subtracted(region):
                     # paint background, still partly uncovered
-                    painter.fillRect(rect, paperColor)
+                    painter.fillRect(rect, page.paperColor or self.paperColor)
 
         # draw lowest quality images first
         for (r, image, source) in reversed(images):
             # scale the target rect back to the paint device
             target = QRectF(r.x() / info.ratio, r.y() / info.ratio, r.width() / info.ratio, r.height() / info.ratio)
-            # remember render() does not fill the background unless requested
-            painter.fillRect(target, paperColor)
+            # job() already filled the background when rendering the page
+            # so we don't have to do that separately, which can cause flicker
             painter.drawImage(target, image, source)
 
     def schedule(self, page, key, tiles, callback):
@@ -399,7 +398,9 @@ class AbstractRenderer:
         exception = []
         def work():
             try:
-                return self.render(page, key, tile)
+                # filling the background here is an optimization for paint()
+                return self.render(page, key, tile,
+                                   page.paperColor or self.paperColor)
             except Exception:
                 exception.extend(sys.exc_info())
                 return QImage()


### PR DESCRIPTION
Previously the background was painted or erased several times in separate parts of the code when rendering a PDF page. This was partly my own fault, as I did not fully understand the rendering logic when I first wrote the QtPDF backend (the previous Poppler backend I used as a reference also overrode significant parts of it).

This new code only paints the background once, and only when necessary to do so. For example, it's not necessary or desirable to paint the background when printing.

Another consequence of this fix is that it's possible now to render an image with a transparent background, for example in Frescobaldi's copy-to-image dialog. I believe this was how it worked in older versions of qpageview, and was also the intended behavior here all along.