### PR TITLE
Add tiling support to the QtPDF backend

### DIFF
--- a/qpageview/pdf.py
+++ b/qpageview/pdf.py
@@ -303,10 +303,6 @@ class PdfRenderer(render.AbstractRenderer):
                 Qt.AspectRatioMode.IgnoreAspectRatio,
                 Qt.TransformationMode.SmoothTransformation)
 
-        # Erase the target area and draw the image
-        painter.eraseRect(target)
-        if paperColor:
-            painter.fillRect(target, paperColor)
         painter.drawImage(target, image, QRectF(image.rect()))
 
 

--- a/qpageview/pdf.py
+++ b/qpageview/pdf.py
@@ -49,8 +49,6 @@ from . import link
 from . import locking
 from . import render
 
-_jobs = render._jobs
-
 
 class Link(link.Link):
     """A link that encapsulates QPdfLinkModel data."""
@@ -222,6 +220,7 @@ class PdfDocument(document.SingleSourceDocument):
 
 class PdfRenderer(render.AbstractRenderer):
     oversampleThreshold = 96    # DPI of a standard PC screen
+    renderFullPages = True      # QtPDF doesn't support partial page rendering
 
     def draw(self, page, painter, key, tile, paperColor=None):
         """Draw a tile on the painter.
@@ -296,55 +295,6 @@ class PdfRenderer(render.AbstractRenderer):
                 Qt.TransformationMode.SmoothTransformation)
 
         painter.drawImage(target, image, QRectF(image.rect()))
-
-    def schedule(self, page, key, tiles, callback):
-        """Schedule a new rendering job for the specified page.
-
-        If this page has already a job pending, the callback is added to the
-        pending job.
-
-        """
-        import time
-        # render the full page now, then job() will split it into tiles later
-        pageTile = render.Tile(0, 0, key.width, key.height)
-        try:
-            job = _jobs[(key, pageTile)]
-        except KeyError:
-            # make a new Job for this page
-            job = _jobs[(key, pageTile)] = self.job(page, key, pageTile)
-        job.time = time.time()
-        job.callbacks.add(callback)
-        self.checkstart()
-
-    def job(self, page, key, pageTile):
-        """Return a new :class:`~.backgroundjob.Job` tailored for this page."""
-        from . import backgroundjob
-        job = backgroundjob.Job()
-        job.callbacks = callbacks = set()
-        job.mutex = page.mutex()
-        exception = []
-        def work():
-            try:
-                # filling the background here is an optimization for paint()
-                return self.render(page, key, pageTile,
-                                   page.paperColor or self.paperColor)
-            except Exception:
-                exception.extend(sys.exc_info())
-                return QImage()
-        def finalize(image):
-            # split the rendered page into tiles
-            for tile in self.tiles(key.width, key.height):
-                self.cache.addtile(key, tile,
-                                   image.copy(QRect(*map(int, tile))))
-            for cb in callbacks:
-                cb(page)
-            del _jobs[(key, pageTile)]
-            self.checkstart()
-            if exception:
-                self.exception(*exception)
-        job.work = work
-        job.finalize = finalize
-        return job
 
 
 def load(source):

--- a/qpageview/pdf.py
+++ b/qpageview/pdf.py
@@ -49,6 +49,8 @@ from . import link
 from . import locking
 from . import render
 
+_jobs = render._jobs
+
 
 class Link(link.Link):
     """A link that encapsulates QPdfLinkModel data."""
@@ -221,16 +223,6 @@ class PdfDocument(document.SingleSourceDocument):
 class PdfRenderer(render.AbstractRenderer):
     oversampleThreshold = 96    # DPI of a standard PC screen
 
-    def tiles(self, width, height):
-        """Yield four-tuples Tile(x, y, w, h) describing the tiles to render.
-
-        For the QtPdf backend, this always returns a single tile covering
-        the entire page because QtPdf does not support selectively rendering
-        a smaller area.
-
-        """
-        yield render.Tile(0, 0, width, height)
-
     def draw(self, page, painter, key, tile, paperColor=None):
         """Draw a tile on the painter.
 
@@ -304,6 +296,55 @@ class PdfRenderer(render.AbstractRenderer):
                 Qt.TransformationMode.SmoothTransformation)
 
         painter.drawImage(target, image, QRectF(image.rect()))
+
+    def schedule(self, page, key, tiles, callback):
+        """Schedule a new rendering job for the specified page.
+
+        If this page has already a job pending, the callback is added to the
+        pending job.
+
+        """
+        import time
+        # render the full page now, then job() will split it into tiles later
+        pageTile = render.Tile(0, 0, key.width, key.height)
+        try:
+            job = _jobs[(key, pageTile)]
+        except KeyError:
+            # make a new Job for this page
+            job = _jobs[(key, pageTile)] = self.job(page, key, pageTile)
+        job.time = time.time()
+        job.callbacks.add(callback)
+        self.checkstart()
+
+    def job(self, page, key, pageTile):
+        """Return a new :class:`~.backgroundjob.Job` tailored for this page."""
+        from . import backgroundjob
+        job = backgroundjob.Job()
+        job.callbacks = callbacks = set()
+        job.mutex = page.mutex()
+        exception = []
+        def work():
+            try:
+                # filling the background here is an optimization for paint()
+                return self.render(page, key, pageTile,
+                                   page.paperColor or self.paperColor)
+            except Exception:
+                exception.extend(sys.exc_info())
+                return QImage()
+        def finalize(image):
+            # split the rendered page into tiles
+            for tile in self.tiles(key.width, key.height):
+                self.cache.addtile(key, tile,
+                                   image.copy(QRect(*map(int, tile))))
+            for cb in callbacks:
+                cb(page)
+            del _jobs[(key, pageTile)]
+            self.checkstart()
+            if exception:
+                self.exception(*exception)
+        job.work = work
+        job.finalize = finalize
+        return job
 
 
 def load(source):

--- a/qpageview/render.py
+++ b/qpageview/render.py
@@ -219,17 +219,15 @@ class AbstractRenderer:
         The default implementation prepares the image, a painter and then
         calls draw() to actually draw the contents.
 
-        If the paperColor is not specified, it will be read from the Page's
-        paperColor attribute (if not None) or else from the renderer's
-        paperColor attribute.
+        If the paperColor is not specified, the returned image will have a
+        transparent background, and the caller is responsible to paint or
+        erase the background as needed before calling this method.
 
         """
-        if paperColor is None:
-            paperColor = page.paperColor or self.paperColor
-
         i = QImage(tile.w, tile.h, self.imageFormat)
-        if paperColor:
-            i.fill(paperColor)
+        # leave the background transparent if no paperColor is specified,
+        # since we don't necessarily want to fill it e.g. when printing
+        i.fill(paperColor or Qt.GlobalColor.transparent)
         painter = QPainter(i)
 
         # rotate the painter accordingly
@@ -333,6 +331,7 @@ class AbstractRenderer:
         region = QRegion() # painted region in tile coordinates
 
         info = self.info(page, painter.device(), rect)
+        paperColor = page.paperColor or self.paperColor
 
         for t, image in info.images:
             r = QRect(*t) & info.target # part of the tile that needs to be drawn
@@ -365,12 +364,14 @@ class AbstractRenderer:
             else:
                 if QRegion(info.target).subtracted(region):
                     # paint background, still partly uncovered
-                    painter.fillRect(rect, page.paperColor or self.paperColor)
+                    painter.fillRect(rect, paperColor)
 
         # draw lowest quality images first
         for (r, image, source) in reversed(images):
             # scale the target rect back to the paint device
             target = QRectF(r.x() / info.ratio, r.y() / info.ratio, r.width() / info.ratio, r.height() / info.ratio)
+            # remember render() does not fill the background unless requested
+            painter.fillRect(target, paperColor)
             painter.drawImage(target, image, source)
 
     def schedule(self, page, key, tiles, callback):

--- a/qpageview/render.py
+++ b/qpageview/render.py
@@ -391,10 +391,10 @@ class AbstractRenderer:
             # ignore the caller's request and always render the full page;
             # job() will do the actual division into tiles later
             tiles = [Tile(0, 0, key.width, key.height)]
-            # ensure the cache can always hold at least two full pages to
-            # avoid re-rendering when scrolling over a page break
+            # ensure the cache can always hold at least one full page (or two
+            # half-pages) to avoid excessive re-rendering at higher zoom levels
             pageBytes = key.width * key.height * 4  # 32 bits == 4 bytes
-            self.cache.maxsize = max(cache.ImageCache.maxsize, pageBytes * 2)
+            self.cache.maxsize = max(cache.ImageCache.maxsize, pageBytes)
         for tile in tiles:
             try:
                 job = _jobs[(key, tile)]

--- a/qpageview/render.py
+++ b/qpageview/render.py
@@ -391,10 +391,10 @@ class AbstractRenderer:
             # ignore the caller's request and always render the full page;
             # job() will do the actual division into tiles later
             tiles = [Tile(0, 0, key.width, key.height)]
-            # ensure the cache can always hold at least one full page (or two
-            # half-pages) to avoid excessive re-rendering at higher zoom levels
+            # ensure the cache can always hold at least two full pages to
+            # avoid excessive re-rendering at higher zoom levels
             pageBytes = key.width * key.height * 4  # 32 bits == 4 bytes
-            self.cache.maxsize = max(cache.ImageCache.maxsize, pageBytes)
+            self.cache.maxsize = max(cache.ImageCache.maxsize, pageBytes * 2)
         for tile in tiles:
             try:
                 job = _jobs[(key, tile)]

--- a/qpageview/render.py
+++ b/qpageview/render.py
@@ -331,7 +331,6 @@ class AbstractRenderer:
         region = QRegion() # painted region in tile coordinates
 
         info = self.info(page, painter.device(), rect)
-        paperColor = page.paperColor or self.paperColor
 
         for t, image in info.images:
             r = QRect(*t) & info.target # part of the tile that needs to be drawn
@@ -364,14 +363,14 @@ class AbstractRenderer:
             else:
                 if QRegion(info.target).subtracted(region):
                     # paint background, still partly uncovered
-                    painter.fillRect(rect, paperColor)
+                    painter.fillRect(rect, page.paperColor or self.paperColor)
 
         # draw lowest quality images first
         for (r, image, source) in reversed(images):
             # scale the target rect back to the paint device
             target = QRectF(r.x() / info.ratio, r.y() / info.ratio, r.width() / info.ratio, r.height() / info.ratio)
-            # remember render() does not fill the background unless requested
-            painter.fillRect(target, paperColor)
+            # job() already filled the background when rendering the page
+            # so we don't have to do that separately, which can cause flicker
             painter.drawImage(target, image, source)
 
     def schedule(self, page, key, tiles, callback):
@@ -399,7 +398,9 @@ class AbstractRenderer:
         exception = []
         def work():
             try:
-                return self.render(page, key, tile)
+                # filling the background here is an optimization for paint()
+                return self.render(page, key, tile,
+                                   page.paperColor or self.paperColor)
             except Exception:
                 exception.extend(sys.exc_info())
                 return QImage()

--- a/qpageview/render.py
+++ b/qpageview/render.py
@@ -391,6 +391,10 @@ class AbstractRenderer:
             # ignore the caller's request and always render the full page;
             # job() will do the actual division into tiles later
             tiles = [Tile(0, 0, key.width, key.height)]
+            # ensure the cache can always hold at least two full pages to
+            # avoid re-rendering when scrolling over a page break
+            pageBytes = key.width * key.height * 4  # 32 bits == 4 bytes
+            self.cache.maxsize = max(cache.ImageCache.maxsize, pageBytes * 2)
         for tile in tiles:
             try:
                 job = _jobs[(key, tile)]

--- a/qpageview/render.py
+++ b/qpageview/render.py
@@ -112,6 +112,13 @@ class AbstractRenderer:
     # antialias True by default (not all renderers may support this)
     antialiasing = True
 
+    # qpageview was designed to render pages tile-by-tile. However, some
+    # backends like QtPDF only support full-page rendering, so for these we
+    # render the page first and divide it into tiles later. This is less
+    # efficient, but still provides certain performance advantages of using
+    # tiles like reduced flicker when repainting the widget.
+    renderFullPages = False
+
     def __init__(self, cache=None):
         if cache:
             self.cache = cache
@@ -380,6 +387,10 @@ class AbstractRenderer:
         pending job.
 
         """
+        if self.renderFullPages:
+            # ignore the caller's request and always render the full page;
+            # job() will do the actual division into tiles later
+            tiles = [Tile(0, 0, key.width, key.height)]
         for tile in tiles:
             try:
                 job = _jobs[(key, tile)]
@@ -405,7 +416,12 @@ class AbstractRenderer:
                 exception.extend(sys.exc_info())
                 return QImage()
         def finalize(image):
-            self.cache.addtile(key, tile, image)
+            if self.renderFullPages:
+                for subtile in self.tiles(key.width, key.height):
+                    self.cache.addtile(key, subtile,
+                                       image.copy(QRect(*map(int, subtile))))
+            else:
+                self.cache.addtile(key, tile, image)
             for cb in callbacks:
                 cb(page)
             del _jobs[(key, tile)]


### PR DESCRIPTION
This greatly improves performance at the cost of momentarily higher memory usage when rendering the page.

Because of QtPDF limitations, this is implemented by rendering the entire page at once, then splitting it into tiles that are cached and displayed individually. This is less efficient than rendering tile-by-tile, as qpageview was intended to do (but which QtPDF does not currently support). However, it still provides important performance advantages of using tiles like reduced flicker when repainting.

In practice, this will have the most noticeable impact at higher zoom levels, as lower zoom levels render the full page at once anyway.