### PR TITLE
Optimize the cache size to avoid unnecessary re-rendering

### DIFF
--- a/qpageview/cache.py
+++ b/qpageview/cache.py
@@ -69,6 +69,23 @@ class ImageCache:
         except KeyError:
             return {}
 
+    def prepare(self, tiles):
+        """Make room before rendering new tiles.
+
+        This ensures there is space for the new tiles by adjusting
+        the cache size and/or purging older images as needed.
+
+        """
+        # approximate size of the new tiles at 32 bits (== 4 bytes) per pixel
+        tileBytes = sum(tile.w * tile.h for tile in tiles) * 4
+
+        # adjust the cache size to fit at least two pages' visible tiles
+        # to avoid re-rendering either page when both are displayed
+        self.maxsize = max(type(self).maxsize, 2 * tileBytes)
+
+        # free memory from unneeded tiles before rendering the new ones
+        self.purge(tileBytes)
+
     def addtile(self, key, tile, image):
         """Add image for the specified key and tile."""
         d = self._cache.setdefault(key.group, {}).setdefault(key.ident, {}).setdefault(key[2:], {})
@@ -80,12 +97,17 @@ class ImageCache:
         e = d[tile] = ImageEntry(image)
         self.currentsize += e.bcount
 
-        if self.currentsize <= self.maxsize:
+    def purge(self, reservedsize=0):
+        """Purge old images if needed.
+
+        At least `reservedsize` bytes will remain available.
+
+        """
+        limit = self.maxsize - reservedsize
+        if self.currentsize <= limit:
             return
 
-        # purge old images is needed,
         # cache groups may have disappeared so count all images
-
         entries = iter(sorted(
             ((entry.time, entry.bcount, group, ident, key, tile)
             for group, identd in self._cache.items()
@@ -94,11 +116,11 @@ class ImageCache:
                         for tile, entry in tiled.items()),
             key=(lambda item: item[:2]), reverse=True))
 
-        # now count the newest images until maxsize ...
+        # now count the newest images until our limit ...
         currentsize = 0
         for time, bcount, group, ident, key, tile in entries:
             currentsize += bcount
-            if currentsize >= self.maxsize:
+            if currentsize >= limit:
                 break
         self.currentsize = currentsize
         # ... and delete the remaining images, deleting empty dicts as well

--- a/qpageview/cache.py
+++ b/qpageview/cache.py
@@ -81,10 +81,15 @@ class ImageCache:
 
         # adjust the cache size to fit at least two pages' visible tiles
         # to avoid re-rendering either page when both are displayed
+        oldsize = self.maxsize
         self.maxsize = max(type(self).maxsize, 2 * tileBytes)
-
-        # free memory from unneeded tiles before rendering the new ones
-        self.purge(tileBytes)
+        if self.maxsize < oldsize:
+            # clear everything when shrinking the cache because otherwise
+            # larger tiles might prove difficult to purge()
+            self.clear()
+        else:
+            # free memory from unneeded tiles before rendering the new ones
+            self.purge(tileBytes)
 
     def addtile(self, key, tile, image):
         """Add image for the specified key and tile."""

--- a/qpageview/cache.py
+++ b/qpageview/cache.py
@@ -77,12 +77,10 @@ class ImageCache:
         except KeyError:
             pass
 
-        purgeneeded = self.currentsize > self.maxsize
-
         e = d[tile] = ImageEntry(image)
         self.currentsize += e.bcount
 
-        if not purgeneeded:
+        if self.currentsize <= self.maxsize:
             return
 
         # purge old images is needed,
@@ -100,7 +98,7 @@ class ImageCache:
         currentsize = 0
         for time, bcount, group, ident, key, tile in entries:
             currentsize += bcount
-            if currentsize > self.maxsize:
+            if currentsize >= self.maxsize:
                 break
         self.currentsize = currentsize
         # ... and delete the remaining images, deleting empty dicts as well

--- a/qpageview/render.py
+++ b/qpageview/render.py
@@ -380,6 +380,11 @@ class AbstractRenderer:
         pending job.
 
         """
+        # adjust the cache size to fit at least two pages' visible tiles
+        # to avoid re-rendering either page when both are displayed
+        # derivation: tile area * (32 bits == 4 bytes / pixel) * 2 pages
+        self.cache.maxsize = max(type(self.cache).maxsize,
+                                 8 * sum(tile.w * tile.h for tile in tiles))
         for tile in tiles:
             try:
                 job = _jobs[(key, tile)]

--- a/qpageview/render.py
+++ b/qpageview/render.py
@@ -380,11 +380,7 @@ class AbstractRenderer:
         pending job.
 
         """
-        # adjust the cache size to fit at least two pages' visible tiles
-        # to avoid re-rendering either page when both are displayed
-        # derivation: tile area * (32 bits == 4 bytes / pixel) * 2 pages
-        self.cache.maxsize = max(type(self.cache).maxsize,
-                                 8 * sum(tile.w * tile.h for tile in tiles))
+        self.cache.prepare(tiles)
         for tile in tiles:
             try:
                 job = _jobs[(key, tile)]


### PR DESCRIPTION
At higher zoom levels, the hard-coded limit of 200MB may be too small to hold all the displayed tiles, forcing them to be re-rendered each time the widget is repainted. This in turn can cause flickering as the tiles are erased, re-rendered, and repainted. This is especially noticeable when scrolling over a page break; rendering each page purges the other's tiles from cache, causing both to be re-rendered at each increment.

This PR scales the cache size dynamically with the page size to prevent re-rendering in this scenario while still limiting memory usage as much as possible. It also makes several improvements to the cache logic, such as purging old tiles before rather than after rendering new ones, to further limit memory usage even with a larger cache size.