### PR TITLE
Use __slots__ to save memory on heavily-used data classes

### DIFF
--- a/qpageview/backgroundjob.py
+++ b/qpageview/backgroundjob.py
@@ -105,6 +105,8 @@ class SingleRun:
     old one finishes.
 
     """
+    __slots__ = ("_job")
+
     def __init__(self):
         self._job = None
 

--- a/qpageview/cache.py
+++ b/qpageview/cache.py
@@ -28,6 +28,8 @@ import time
 
 
 class ImageEntry:
+    __slots__ = ("image", "bcount", "time")
+
     def __init__(self, image):
         self.image = image
         self.bcount = image.sizeInBytes()

--- a/qpageview/link.py
+++ b/qpageview/link.py
@@ -40,21 +40,16 @@ Area = collections.namedtuple("Area", "left top right bottom")
 
 
 class Link:
-    fileName = ""
-    isExternal = False
-    targetPage = -1
-    url = ""
-    tooltip = ""
-    area = Area(0, 0, 0, 0)
+    __slots__ = (
+        "fileName", "isExternal", "targetPage", "url", "tooltip", "area")
 
     def __init__(self, left, top, right, bottom, url=None, tooltip=None):
+        self.fileName = ""
         self.area = Area(left, top, right, bottom)
-        if url:
-            self.url = url
-            if "://" in url:
-                self.isExternal = True
-        if tooltip:
-            self.tooltip = tooltip
+        self.url = url or ""
+        self.isExternal = ("://" in self.url)
+        self.tooltip = tooltip or ""
+        self.targetPage = -1
 
     def rect(self):
         """Return the area attribute as a QRectF()."""

--- a/qpageview/pdf.py
+++ b/qpageview/pdf.py
@@ -51,6 +51,8 @@ from . import render
 
 class Link(link.Link):
     """A link that encapsulates QPdfLinkModel data."""
+    __slots__ = ("_targetPage", "_url")
+
     def __init__(self, linkobj, index, pointSize):
         self._targetPage = linkobj.data(index, QPdfLinkModel.Role.Page.value)
         self._url = linkobj.data(index,

--- a/qpageview/rectangles.py
+++ b/qpageview/rectangles.py
@@ -51,6 +51,8 @@ class Rectangles:
     once. x should be < x2 and y should be < y2.
 
     """
+    __slots__ = ("_items", "_index")
+
     def __init__(self, objects=None):
         """Initializes the Rectangles object.
 

--- a/qpageview/util.py
+++ b/qpageview/util.py
@@ -80,6 +80,8 @@ class Rectangular:
 
 class MapToPage:
     """Simple class wrapping a QTransform to map rect and point to page coordinates."""
+    __slots__ = ("t")
+
     def __init__(self, transform):
         self.t = transform
 


### PR DESCRIPTION
This PR uses Python's [`__slots__` mechanism](https://docs.python.org/3/reference/datamodel.html#slots) to reduce the memory footprint of several data classes associated with links, cache entries, and various internal uses. The classes in question all have well-known, fixed attributes, and there are typically tens of their objects in memory at any given time, so any improvements to them would be expected to have a measurable impact. In testing I found these changes lowered Frescobaldi's memory usage by several megabytes when displaying a large score.